### PR TITLE
Remove references to gym-ignition-models

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,6 @@ outputs:
         - pip
         - pytest
         - icub-models
-        - gym-ignition-models
         - idyntree
         - git
         - gitpython
@@ -74,7 +73,6 @@ outputs:
         - pip
         - pytest
         - icub-models
-        - gym-ignition-models
         - idyntree
         - git
         - gitpython
@@ -100,7 +98,6 @@ outputs:
         - pip
         - pytest
         - icub-models
-        - gym-ignition-models
         - idyntree
         - git
         - gitpython
@@ -127,7 +124,6 @@ outputs:
         - pip
         - pytest
         - icub-models
-        - gym-ignition-models
         - idyntree
         - git
         - gitpython
@@ -156,7 +152,6 @@ outputs:
         - pip
         - pytest
         - icub-models
-        - gym-ignition-models
         - idyntree
         - git
         - gitpython


### PR DESCRIPTION
The dependency was dropped upstream in https://github.com/ami-iit/adam/pull/44, so I think we can also remove the reference here.

xref: https://github.com/robotology/gym-ignition-models/issues/36

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
